### PR TITLE
Default value not reflected in selected state on initial render

### DIFF
--- a/resources/views/components/checkbox/cards.blade.php
+++ b/resources/views/components/checkbox/cards.blade.php
@@ -67,18 +67,12 @@
                     @endif
 
                     x-data="{
-                        isSelected: false,
+                        isSelected: @js(in_array($value, (array) ($getState() ?? $getDefaultState() ?? []))),
                         init() {
-                            this.updateSelectedState();
-
-                            this.$watch('$wire.{{ $statePath }}', () => {
-                                this.updateSelectedState();
+                            this.$watch('$wire.{{ $statePath }}', (newValue) => {
+                                const value = Array.isArray(newValue) ? newValue : [];
+                                this.isSelected = value.includes('{{ $value }}');
                             });
-                        },
-                        updateSelectedState() {
-                            const currentValue = $wire.get('{{ $statePath }}');
-                            const value = Array.isArray(currentValue) ? currentValue : [];
-                            this.isSelected = value.includes('{{ $value }}');
                         }
                     }"
                     @class([

--- a/resources/views/components/radio/cards.blade.php
+++ b/resources/views/components/radio/cards.blade.php
@@ -44,17 +44,11 @@
                     'is-centered' => $isItemsCenter(),
                 ])
                 x-data="{
-                    isSelected: false,
+                    isSelected: @js(($getState() ?? $getDefaultState()) === $value),
                     init() {
-                        this.updateSelectedState();
-
-                        this.$watch('$wire.{{ $statePath }}', () => {
-                            this.updateSelectedState();
+                        this.$watch('$wire.{{ $statePath }}', (newValue) => {
+                            this.isSelected = String(newValue ?? '') === '{{ $value }}';
                         });
-                    },
-                    updateSelectedState() {
-                        const currentValue = $wire.get('{{ $statePath }}');
-                        this.isSelected = (currentValue ?? '') === '{{ $value }}';
                     }
                 }"
                 :class="{ 'is-selected': isSelected }"


### PR DESCRIPTION
  When using ->default() on RadioCards/CheckboxCards, the selected visual state was always false on
  initial page load, even though the form value was correctly set.

  Root cause: The Alpine init() method called updateSelectedState() which used $wire.get() to read
  the state. However, Livewire hadn't hydrated the form state yet, so it returned empty/null,
  overwriting the correct value.

  Fix: Compute the initial isSelected value server-side using Blade's @js() with $getState() ??
  $getDefaultState(). The $watch now only handles subsequent user interactions.

  // Before
  isSelected: false,

  // After
  isSelected: @js(($getState() ?? $getDefaultState()) === $value)