### PR TITLE
fix: Do not use undefined method String

### DIFF
--- a/resources/views/components/radio/cards.blade.php
+++ b/resources/views/components/radio/cards.blade.php
@@ -44,10 +44,10 @@
                     'is-centered' => $isItemsCenter(),
                 ])
                 x-data="{
-                    isSelected: @js(String($getState() ?? $getDefaultState() ?? '') === String($value)),
+                    isSelected: @js(($getState() ?? $getDefaultState() ?? '') === $value),
                     init() {
                         this.$watch('$wire.{{ $statePath }}', (newValue) => {
-                            this.isSelected = String(newValue ?? '') === '{{ $value }}';
+                            this.isSelected = (newValue ?? '') === '{{ $value }}';
                         });
                     }
                 }"


### PR DESCRIPTION
Fix for #9
$getState(), $getDefaultState() and newValue are already string so we don't need to do anything else!